### PR TITLE
changes to readme.md (also for Mirzah to copy to wiki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,43 +6,35 @@ This is a collection of scripts to help convert ROS stacks to Catkin.
 Installing
 ----------
 
-	sudo python setup.py install	
+	sudo python setup.py install
 
 Example
 -------
 
     # Start by running through the getting started guide at
     # http://ros.org/doc/groovy/api/catkin/html/user_guide/getting_started.html
+    # This should give you a valid catkin groovy workspace at ~/groovy_overlay
 
     # Next, check out a ROS stack that hasn't yet been converted to Catkin
     source ~/groovy_overlay/build/buildspace/setup.sh
     cd ~/groovy_overlay/src
-	hg clone https://kforge.ros.org/common/filters
-	cd filters
+    hg clone https://kforge.ros.org/common/filters
+    cd filters
 
-	# Set up a git repository
-	git init
-	git add .
-	alias gcam='git commit -a -m'
-	gcam 'Version before converting to Catkin'
+    # Convert CMakeLists.txt
+    mv CMakeLists.txt CMakeLists.old
+    catkinize_cmakelists.py filters CMakeLists.old manifest.xml > CMakeLists.txt
+    # now check and adapt the CMakeLists.txt with any text editor
+    $EDITOR CMakeLists.txt  # Make any changes needed
 
-	# Convert CMakeLists.txt
-	mv CMakeLists.txt CMakeLists.old
-	catkinize_cmakelists.py filters CMakeLists.old manifest.xml > CMakeLists.txt
-	gcam 'Run catkinize_cmakelists'
-	$EDITOR CMakeLists.txt  # Make any changes needed
-	gcam 'More Catkinization of CMakeLists'
+    # Convert manifest.xml to package.xml
+    catkinize_manifest_xml_to_package_xml.py manifest.xml filters 1.6.0 \
+      > package.xml
 
-	# Convert manifest.xml to package.xml
-	catkinize_manifest_xml_to_package_xml.py -a manifest.xml filters 1.6.0 \
-		> package.xml
-	git add package.xml
-	gcam 'Generate package.xml from manifest.xml'
-	# Edit package.xml:
-	#  - Make sure there is a valid maintainer
-	#  - Uncomment dependencies as needed
-	$EDITOR package.xml
-	gcam 'More Catkinization of package.xml'
+    # Edit package.xml:
+    #  - Make sure there is a valid maintainer
+    #  - Uncomment dependencies as needed
+    $EDITOR package.xml
 
     # Check the results
     cd ~/groovy_overlay/build


### PR DESCRIPTION
- fix trailing whitespaces and leading tabs
- remove all mention of git
- removed -a

I am sure using git was well-meant, but not
only is it unnecessary for this use-case, but
also confusing because we are working with an example
taken from a mercurial repository, and it would be far
more natural to use hg versioning. Since your example
creates a manual backup anyway, even novice users should
be safe when replicating with their own code.

Removing -a because it would be too tempting for novice
users to copy this without thinking about it.
