### PR TITLE
Adding email attribute, uncommenting deps by default, and dding some inline documentation

### DIFF
--- a/catkinize/convert_manifest.py
+++ b/catkinize/convert_manifest.py
@@ -339,13 +339,13 @@ def create_project_xml(package_name, version, description, maintainers,
 
 %(authors_part)s
 
-<!-- Dependencies needed to compile this pacakge. -->
+  <!-- Dependencies needed to compile this pacakge. -->
 %(build_depends_part)s
 
-<!-- Dependencies needed after this package is compiled. -->
+  <!-- Dependencies needed after this package is compiled. -->
 %(run_depends_part)s
 
-<!-- Dependencies needed only for running tests. -->
+  <!-- Dependencies needed only for running tests. -->
 %(test_depends_part)s
 
 %(replaces_part)s


### PR DESCRIPTION
This PR does a few things:
1. It adds a default (empty) e-mail attribute, so people can just add the e-mail itself. It's worth noting that an empty maintainer e-mail address prevents a catkin package from building even if the maintainer tag is there.
2. It uncomments the run_depend and build_depend tags by default, since I think this is the first thing that everyone does after they run this script. Even if they plan to clean them up afterwards. It leaves the test_depend tags commented.
3. It adds a couple of lines of documentation at a high level explaining the three different dependency groups.

The goal of all this is to reduce the amount of typing someone needs to do to convert things to catkin. This fixes https://github.com/ros-infrastructure/catkinize/issues/14
