### PR TITLE
Refactor/Simplification changeset

### DIFF
--- a/catkinize/handle_all.py
+++ b/catkinize/handle_all.py
@@ -6,7 +6,9 @@ from __future__ import print_function
 import sys
 
 from handle_manifest import handle_manifest
+from handle_make import handle_make
 from utils import is_valid_version
+from utils import confirm
 
 
 if __name__ == "__main__":
@@ -22,7 +24,7 @@ if __name__ == "__main__":
     possible = (
         handle_manifest(package_path, version, dryrun=True) and
         # handle_cmake(package_path, version, dryrun=True) and
-        # handle_make(package_path, version, dryrun=True)
+        handle_make(package_path, dryrun=True),
         True
     )
 
@@ -33,7 +35,7 @@ if __name__ == "__main__":
     if confirm("Continue? [y/n]", "y"):
         handle_manifest(package_path, version, dryrun=False)
         # handle_cmake(package_path, version, dryrun=False)
-        # handle_make(package_path, version, dryrun=False)
+        handle_make(package_path, dryrun=False)
 
     else:
         print("You aborted catkinizing.")

--- a/catkinize/handle_all.py
+++ b/catkinize/handle_all.py
@@ -11,7 +11,7 @@ from utils import is_valid_version
 from utils import confirm
 
 
-if __name__ == "__main__":
+def _catkinize_package():
     # TODO user arsparser
     package_path = sys.argv[1]
     package_name = sys.argv[2]
@@ -39,3 +39,7 @@ if __name__ == "__main__":
 
     else:
         print("You aborted catkinizing.")
+
+
+if __name__ == "__main__":
+    _catkinize_package()

--- a/catkinize/handle_all.py
+++ b/catkinize/handle_all.py
@@ -1,25 +1,31 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
 from __future__ import print_function
 
 import sys
+
 from handle_manifest import handle_manifest
+from utils import is_valid_version
 
 
 if __name__ == "__main__":
     # TODO user arsparser
-    version = sys.args[1]
+    package_path = sys.argv[1]
+    package_name = sys.argv[2]
+    version = sys.argv[3]
+
     if not is_valid_version(version):
-        print("not a valid version")
+        print("%s is not a valid version" % version)
         sys.exit(-1)
 
-    package_path = sys.args[2]
+    possible = (
+        handle_manifest(package_path, version, dryrun=True) and
+        # handle_cmake(package_path, version, dryrun=True) and
+        # handle_make(package_path, version, dryrun=True)
+        True
+    )
 
-    # possible = handle_manifest(dryrun=True) and handle_cmake(dryrun=True) and handle_make(dryrun=True)
-
-    possible = (handle_manifest(package_path, version, dryrun=True) and
-                # handle_cmake(package_path, version, dryrun=True) and
-                # handle_make(package_path, version, dryrun=True)
-                True
-                )
     if not possible:
         print("Errors occured, aborting.")
         sys.exit(-1)

--- a/catkinize/handle_all.py
+++ b/catkinize/handle_all.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 from handle_manifest import handle_manifest
 
@@ -20,8 +22,9 @@ if __name__ == "__main__":
                 )
     if not possible:
         print("Errors occured, aborting.")
+        sys.exit(-1)
 
-    if confirm('Continue?'):
+    if confirm("Continue? [y/n]", "y"):
         handle_manifest(package_path, version, dryrun=False)
         # handle_cmake(package_path, version, dryrun=False)
         # handle_make(package_path, version, dryrun=False)

--- a/catkinize/handle_all.py
+++ b/catkinize/handle_all.py
@@ -1,0 +1,30 @@
+import sys
+from handle_manifest import handle_manifest
+
+
+if __name__ == "__main__":
+    # TODO user arsparser
+    version = sys.args[1]
+    if not is_valid_version(version):
+        print("not a valid version")
+        sys.exit(-1)
+
+    package_path = sys.args[2]
+
+    # possible = handle_manifest(dryrun=True) and handle_cmake(dryrun=True) and handle_make(dryrun=True)
+
+    possible = (handle_manifest(package_path, version, dryrun=True) and
+                # handle_cmake(package_path, version, dryrun=True) and
+                # handle_make(package_path, version, dryrun=True)
+                True
+                )
+    if not possible:
+        print("Errors occured, aborting.")
+
+    if confirm('Continue?'):
+        handle_manifest(package_path, version, dryrun=False)
+        # handle_cmake(package_path, version, dryrun=False)
+        # handle_make(package_path, version, dryrun=False)
+
+    else:
+        print("You aborted catkinizing.")

--- a/catkinize/handle_cmake.py
+++ b/catkinize/handle_cmake.py
@@ -1,0 +1,141 @@
+"""
+Converting CMake is more annoying than converting manifest.xml.
+
+The previous version took each cmake command and converted it, see
+`conversions` and `manual_conversions`.
+
+The denpendencies from the manifest files were added in the appropiate
+positions. The location of most cmake commands was not really edited.
+
+In the end you had a file with lots of TODOs and comments.
+
+Maybe it would be better to have a cleaner version of the catkinized cmake
+file. The "template approach" from the manifest conversion really makes clear
+what happens during the conversion. Maybe we can adopt this approach.
+
+Open questions:
+    - what can we put between `find_packages` and `_catkinize_package`?
+    - what MUST we put between `find_packages` and `_catkinize_package`?
+    - what MUST be put after `_catkinize_package`?
+"""
+
+##############################################################################
+from __future__ import print_function
+import os
+import re
+
+import utils
+
+
+##############################################################################
+CMAKE_TEMPLATE = """\
+# Catkin CMake Standard:
+# http://www.ros.org/doc/groovy/api/catkin/html/user_guide/user_guide.html
+cmake_minimum_required(VERSION 2.8.3)
+project(%(project_name)s)
+
+%(find_packages)s
+
+%(msg_srv_section)s
+
+%(before_catkin_package)s
+
+catkin_package(
+  INCLUDE_DIRS %(include)s
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS %(dependencies)s
+)
+
+%(after_catkin_package)s
+"""
+
+##############################################################################
+MSG_SRV_SECTION = """\
+%(comment_msg)sadd_message_files(DIRECTORY %(msg_dir)s FILES %(msg_files)s)
+%(comment_srv)sadd_service_files(DIRECTORY %(srv_dir)s FILES %(srv_files)s)
+
+%(comment_gen)sgenerate_messages(DEPENDENCIES %(files)s)
+"""
+
+
+##############################################################################
+def handle_cmake(package_path, version, dryrun=True):
+    """TODO add doc"""
+
+    package_name = utils.get_package_name(package_path)
+    cmake_path = utils.get_cmake_path(package_path)
+    manifest_xml_path = utils.get_manifest_xml_path(package_path)
+
+    # GUARDS
+    if not os.path.exists(manifest_xml_path):
+        print("%s does not exist. Aborting." % manifest_xml_path)
+        return False
+
+    if not os.path.exists(cmake_path):
+        print("%s does not exist. Aborting." % cmake_path)
+        return False
+
+    fields = {}
+    # get dependencies from the manifest file
+    # we need to add the dependencies in multiple parts in the cmake file
+    fields["dependencies"] = get_dependencies(manifest_xml_path)
+    fields["package_name"] = package_name
+
+    # read the cmake file
+    with open(cmake_path, 'r') as f:
+        cmake_content = f.read()
+
+    fields["cmake_commands"] = FUNCALL_PATTERN.split(cmake_content)
+
+    cmake_new = get_cmake_new(fields)
+
+    return True
+
+
+##############################################################################
+def get_cmake_new(fields):
+    raise NotImplementedError()
+
+
+def get_dependencies(manifest_xml_path):
+    raise NotImplementedError()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/catkinize/handle_make.py
+++ b/catkinize/handle_make.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+import os
+
+import utils
+
+
+##############################################################################
+DEFAULT_MAKEFILE = "include $(shell rospack find mk)/cmake.mk"
+DEFAULT_MAKEFILE_STACK = "include $(shell rospack find mk)/cmake_stack.mk"
+
+
+##############################################################################
+def handle_make(package_path,  dryrun=True):
+    """Handle the Makefile of the package, i.e., backup the makefile if it has
+    the content of the default Makefiles.
+
+    :package_path: path of the package
+    :dryrun: if dryrun == True then don't perform any file operation
+    :returns: True iff all actions could be performed
+    """
+
+    makefile_path = utils.get_makefile_path(package_path)
+
+    # GUARDS
+    if not os.path.exists(makefile_path):
+        print("%s does not exits" % makefile_path)
+        return False
+
+    makefile_str = open(makefile_path).read()
+    print(makefile_str)
+    if makefile_str not in [DEFAULT_MAKEFILE, DEFAULT_MAKEFILE_STACK]:
+        print("The existing Makefile has custom changes. Nothing is done with "
+              "it")
+        return False
+
+    # Backup old Makefile
+    makefile_backup_path = makefile_path + '.backup'
+    print("Backing up %s to %s." % (makefile_path, makefile_backup_path))
+    if not dryrun:
+        os.rename(makefile_path, makefile_backup_path)
+    print("Done")
+
+    return True

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -89,7 +89,12 @@ def handle_manifest(package_path, version, dryrun=True):
             f.write(package_xml_str)
     print("Done")
 
-    # TODO move manifest.xml to manifest.xml.backup
+    # Backup old manifest.xml
+    manifest_backup_path = manifest_xml_path + '.backup'
+    print("Backing up %s to %s." % (manifest_xml_path, manifest_backup_path))
+    if not dryrun:
+        os.rename(manifest_xml_path, manifest_backup_path)
+    print("Done")
 
     return True
 

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -217,6 +217,17 @@ def make_section(tag_name, rows):
     return '\n'.join(indent(make_tag_from_row(tag_name, row)) for row in rows)
 
 
+def make_exports_section(exports, architecture_independent, metapackage):
+    parts = [make_empty_tag(name, attrs_dict)
+             for name, attrs_dict in exports]
+    if architecture_independent:
+        parts.append('<architecture_independent/>')
+    if metapackage:
+        parts.append('<metapackage/>')
+    parts = [indent(p, 2) for p in parts]
+    return '\n'.join(parts)
+
+
 def make_tag_from_row(name, row):
     """Make an XML tag from a row.
 

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -78,7 +78,6 @@ def handle_manifest(package_path, version, dryrun=True):
     print()
 
     # create manifest_xml_str
-    print("package.xml:")
     package_xml_str = create_package_xml_str(fields)
 
     # writing package.xml
@@ -106,12 +105,11 @@ def create_package_xml_str(fields):
     subs['bugtracker_part'] = indent(bugtracker_part)
 
     subs['authors_part'] = make_section('author', fields["authors"])
-    subs['build_depends_part'] = make_section('build_depend', fields["build_depends"])
-    subs['run_depends_part'] = make_section('run_depend', fields["run_depends"])
-    subs['test_depends_part'] = make_section('test_depend',
-                                             fields["test_depends"])
-    subs['replaces_part'] = make_section('replace', fields["replaces"])
-    subs['conflicts_part'] = make_section('conflict', fields["conflicts"])
+    subs['build_depends_part'] = make_section('build_depend', fields["depends"])
+    subs['run_depends_part'] = make_section('run_depend', fields["depends"])
+    subs['test_depends_part'] = make_section('test_depend', fields["depends"])
+    subs['replaces_part'] = None  # TODO make_section('replace', fields["replaces"])
+    subs['conflicts_part'] = None  # TODO make_section('conflict', fields["conflicts"])
     subs['version'] = fields["version"]
     subs['package_name'] = fields["package_name"]
     subs['description'] = fields["description"]

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -62,7 +62,7 @@ def handle_manifest(package_path, version, dryrun=True):
     TODO: arguments
     """
     package_name = utils.get_package_name(package_path)
-    manifest_xml_path = utils.get_package_path(package_path)
+    manifest_xml_path = utils.get_manifest_xml_path(package_path)
     package_xml_path = utils.get_package_xml_path(package_path)
 
     # GUARDS

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -1,0 +1,89 @@
+from __future__ import print_function
+
+import os
+
+
+##############################################################################
+# The final package is going to look like the PACKAGE_TEMPLATE
+PACKAGE_TEMPLATE = """\
+<package>
+  <name>%(package_name)s</name>
+  <version>%(version)s</version>
+  <description>%(description)s</description>
+%(maintainers_part)s
+
+%(licenses_part)s
+
+  <url type="website">%(website_url)s</url>
+%(bugtracker_part)s
+
+%(authors_part)s
+
+  <!-- Dependencies which this package needs to build itself. -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- Dependencies needed to compile this package. -->
+%(build_depends_part)s
+
+  <!-- Dependencies needed after this package is compiled. -->
+%(run_depends_part)s
+
+  <!-- Dependencies needed only for running tests. -->
+%(test_depends_part)s
+
+%(replaces_part)s
+%(conflicts_part)s
+
+  <export>
+%(exports_part)s
+  </export>
+</package>
+"""
+
+
+##############################################################################
+def handle_manifest(package_path, version, dryrun=True):
+    """Convert the package.xml to a catkinized manifest.xml file.
+
+    TODO: arguments
+    """
+    package_name = get_package_name(package_path)
+    manifest_xml_path = get_manifest_path(package_path)
+    package_xml_path = get_package_xml_path(package_path)
+
+    os.path.basename
+    # guards
+    if not os.path.exists(manifest_xml_path):
+        print("manifest.xml does not exits")
+        return False
+
+    if os.path.exists(package_xml_path):
+        print("package.xml does already exist. Aborting.")
+        return False
+
+    # get all fields
+    with open(manifest_xml_path) as f:
+        fields = get_fields_from_manifest(f)
+
+    # create manifest_xml_str
+    print("package.xml:")
+    manifest_xml_str = create_package_xml_str(fields)
+    print(manifest_xml_str)
+
+    # writing package.xml
+    print("writing package.xml...")
+    if not dryrun:
+        with open(manifest_xml_path, "w") as f:
+            f.write(manifest_xml_str)
+    print("Done")
+
+    return True
+
+
+##############################################################################
+def get_manifest_path(package_path):
+    pass
+
+
+def get_package_xml_path(package_path):
+    pass

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -100,34 +100,26 @@ def handle_manifest(package_path, version, dryrun=True):
 
 
 def create_package_xml_str(fields):
-    subs = {}
-
-    subs['maintainers_part'] = make_section('maintainer', fields["maintainers"])
-
-    subs['licenses_part'] = '\n'.join(
-        indent('<license>%s</license>' % l)
-        for l in fields["licenses"])
-
-    bugtracker_part = '<url type="bugtracker">%s</url>' % fields["bugtracker_url"]
-    if not fields["bugtracker_url"]:
-        bugtracker_part = comment_out(bugtracker_part)
-    subs['bugtracker_part'] = indent(bugtracker_part)
-
-    subs['authors_part'] = make_section('author', fields["authors"])
-    subs['build_depends_part'] = make_section('build_depend', fields["depends"])
-    subs['run_depends_part'] = make_section('run_depend', fields["depends"])
-    subs['test_depends_part'] = make_section_commented("test_depend", fields["depends"])
-    subs['replaces_part'] = ""  # TODO make_section('replace', fields["replaces"])
-    subs['conflicts_part'] = ""  # TODO make_section('conflict', fields["conflicts"])
-    subs['version'] = fields["version"]
-    subs['package_name'] = fields["package_name"]
-    subs['description'] = fields["description"]
-    subs['website_url'] = fields["website_url"]
-    subs['exports_part'] = make_exports_section(
-        fields["exports"],
-        False,  # TODO "architecture_independent
-        False,  # TODO "metapackage"
-    )
+    """Create the xml_str from the given fields dict."""
+    subs = {
+        'maintainers_part': make_section('maintainer', fields["maintainers"]),
+        'licenses_part': make_section("license", fields["licenses"]),
+        'bugtracker_part': make_bugtrackre_section(fields["bugtracker_url"]),
+        'authors_part': make_section('author', fields["authors"]),
+        'build_depends_part': make_section('build_depend', fields["depends"]),
+        'run_depends_part': make_section('run_depend', fields["depends"]),
+        'test_depends_part': make_section_commented("test_depend", fields["depends"]),
+        # TODO make_section('replace', fields["replaces"])
+        'replaces_part': "",
+        # TODO make_section('conflict', fields["conflicts"])
+        'conflicts_part': "",
+        'version': fields["version"],
+        'package_name': fields["package_name"],
+        'description': fields["description"],
+        'website_url': fields["website_url"],
+        # TODO "metapackage" # TODO "architecture_independent
+        'exports_part': make_exports_section( fields["exports"], False,  False),
+    }
     return PACKAGE_TEMPLATE % subs
 
 

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -220,8 +220,25 @@ def get_authors_field(manifest):
 # TODO why don't we use the xml package to create the xml files?
 ##############################################################################
 def make_section(tag_name, rows):
-    """Make a string in XML format for a section with a given tag name."""
+    r"""Make a string in XML format for a section with a given tag name.
+
+    >>> make_section("test_depend", ["std_msgs"])
+    '  <test_depend>std_msgs</test_depend>'
+    >>> make_section("test_depend", ["std_msgs", "geo_msgs"])
+    '  <test_depend>std_msgs</test_depend>\n  <test_depend>geo_msgs</test_depend>'
+    """
     return '\n'.join(indent(make_tag_from_row(tag_name, row)) for row in rows)
+
+
+def make_section_commented(tag_name, rows):
+    r"""
+    >>> make_section_commented("test_depend", ["std_msgs"])
+    '  <!-- <test_depend>std_msgs</test_depend> -->'
+    >>> make_section_commented("test_depend", ["std_msgs", "geo_msgs"])
+    '  <!-- <test_depend>std_msgs</test_depend> -->\n  <!-- <test_depend>geo_msgs</test_depend> -->'
+    """
+    return '\n'.join(indent(comment_out(make_tag_from_row(tag_name, row)))
+                     for row in rows)
 
 
 def make_exports_section(exports, architecture_independent, metapackage):

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -6,15 +6,10 @@ TODO Extract all doctest to proper unittests.
 
 ##############################################################################
 from __future__ import print_function
-
-# standard library imports
 import os
 import re
-
-# related third party imports
 import xml.etree.ElementTree as ET
 
-# local application/library specific imports
 from catkinize import xml_lib
 
 
@@ -33,7 +28,7 @@ PACKAGE_TEMPLATE = """\
 %(authors_part)s
 %(licenses_part)s
   <url type="website">%(website_url)s</url>
-%(bugtracker_part)s
+  %(bugtracker_part)s
 
   <!-- Dependencies which this package needs to build itself. -->
   <buildtool_depend>catkin</buildtool_depend>
@@ -82,9 +77,6 @@ def handle_manifest(package_path, version, dryrun=True):
     fields = get_fields_from_manifest(manifest_xml_path)
     fields["package_name"] = package_name
     fields["version"] = version
-    for k in fields:
-        print("%s --> %s" % (k, fields[k]))
-    print()
 
     # create manifest_xml_str
     package_xml_str = create_package_xml_str(fields)
@@ -96,11 +88,14 @@ def handle_manifest(package_path, version, dryrun=True):
             f.write(package_xml_str)
     print("Done")
 
+    # TODO move manifest.xml to manifest.xml.backup
+
     return True
 
 
 def create_package_xml_str(fields):
     """Create the xml_str from the given fields dict."""
+
     subs = {
         'maintainers_part': make_section('maintainer', fields["maintainers"]),
         'licenses_part': make_section("license", fields["licenses"]),
@@ -118,7 +113,7 @@ def create_package_xml_str(fields):
         'description': fields["description"],
         'website_url': fields["website_url"],
         # TODO "metapackage" # TODO "architecture_independent
-        'exports_part': make_exports_section( fields["exports"], False,  False),
+        'exports_part': make_exports_section(fields["exports"], False,  False),
     }
     return PACKAGE_TEMPLATE % subs
 
@@ -208,7 +203,7 @@ def get_authors_field(manifest):
 
 
 ##############################################################################
-# Make special section in the manifest.xml
+# Make special sections in the manifest.xml
 ##############################################################################
 def make_bugtrackre_section(bugtracker_url):
     """Make the bugtracker section.

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -1,6 +1,14 @@
 from __future__ import print_function
 
+# standard library imports
 import os
+import re
+
+# related third party imports
+import xml.etree.ElementTree as ET
+
+# local application/library specific imports
+from catkinize import xml_lib
 
 
 ##############################################################################

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -51,8 +51,7 @@ def handle_manifest(package_path, version, dryrun=True):
     manifest_xml_path = get_manifest_path(package_path)
     package_xml_path = get_package_xml_path(package_path)
 
-    os.path.basename
-    # guards
+    # GUARDS
     if not os.path.exists(manifest_xml_path):
         print("manifest.xml does not exits")
         return False

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -1,3 +1,10 @@
+"""
+TODO write doc
+
+TODO Extract all doctest to proper unittests.
+"""
+
+##############################################################################
 from __future__ import print_function
 
 # standard library imports
@@ -19,7 +26,9 @@ PACKAGE_TEMPLATE = """\
 <package>
   <name>%(package_name)s</name>
   <version>%(version)s</version>
-  <description>%(description)s</description>
+  <description>
+    %(description)s
+  </description>
 %(maintainers_part)s
 %(authors_part)s
 %(licenses_part)s

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -116,9 +116,9 @@ def create_package_xml_str(fields):
     subs['authors_part'] = make_section('author', fields["authors"])
     subs['build_depends_part'] = make_section('build_depend', fields["depends"])
     subs['run_depends_part'] = make_section('run_depend', fields["depends"])
-    subs['test_depends_part'] = make_section('test_depend', fields["depends"])
-    subs['replaces_part'] = None  # TODO make_section('replace', fields["replaces"])
-    subs['conflicts_part'] = None  # TODO make_section('conflict', fields["conflicts"])
+    subs['test_depends_part'] = make_section_commented("test_depend", fields["depends"])
+    subs['replaces_part'] = ""  # TODO make_section('replace', fields["replaces"])
+    subs['conflicts_part'] = ""  # TODO make_section('conflict', fields["conflicts"])
     subs['version'] = fields["version"]
     subs['package_name'] = fields["package_name"]
     subs['description'] = fields["description"]

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -75,17 +75,17 @@ def handle_manifest(package_path, version, dryrun=True):
     fields["version"] = version
     for k in fields:
         print("%s --> %s" % (k, fields[k]))
-    return False
+    print()
 
     # create manifest_xml_str
     print("package.xml:")
-    manifest_xml_str = create_package_xml_str(fields)
+    package_xml_str = create_package_xml_str(fields)
 
     # writing package.xml
     print("writing package.xml...")
     if not dryrun:
-        with open(manifest_xml_path, "w") as f:
-            f.write(manifest_xml_str)
+        with open(package_xml_path, "w") as f:
+            f.write(package_xml_str)
     print("Done")
 
     return True

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -216,6 +216,35 @@ def get_authors_field(manifest):
 
 
 ##############################################################################
+# Make special section in the manifest.xml
+##############################################################################
+def make_bugtrackre_section(bugtracker_url):
+    """Make the bugtracker section.
+
+    >>> make_bugtrackre_section("www.ros.org")
+    '<url type="bugtracker">www.ros.org</url>'
+    >>> make_bugtrackre_section("")
+    '<!-- <url type="bugtracker"></url> -->'
+    """
+    result = '<url type="bugtracker">%s</url>' % bugtracker_url
+    if bugtracker_url == "":
+        result = comment_out(result)
+    return result
+
+
+def make_exports_section(exports, architecture_independent, metapackage):
+    """Make the export section."""
+    parts = [make_empty_tag(name, attrs_dict)
+             for name, attrs_dict in exports]
+    if architecture_independent:
+        parts.append('<architecture_independent/>')
+    if metapackage:
+        parts.append('<metapackage/>')
+    parts = [indent(p, 2) for p in parts]
+    return '\n'.join(parts)
+
+
+##############################################################################
 # XML formating
 # TODO why don't we use the xml package to create the xml files?
 ##############################################################################
@@ -231,7 +260,8 @@ def make_section(tag_name, rows):
 
 
 def make_section_commented(tag_name, rows):
-    r"""
+    r"""Make a string in XML format for a section with a given tag name and
+    comment out each section.
     >>> make_section_commented("test_depend", ["std_msgs"])
     '  <!-- <test_depend>std_msgs</test_depend> -->'
     >>> make_section_commented("test_depend", ["std_msgs", "geo_msgs"])
@@ -239,17 +269,6 @@ def make_section_commented(tag_name, rows):
     """
     return '\n'.join(indent(comment_out(make_tag_from_row(tag_name, row)))
                      for row in rows)
-
-
-def make_exports_section(exports, architecture_independent, metapackage):
-    parts = [make_empty_tag(name, attrs_dict)
-             for name, attrs_dict in exports]
-    if architecture_independent:
-        parts.append('<architecture_independent/>')
-    if metapackage:
-        parts.append('<metapackage/>')
-    parts = [indent(p, 2) for p in parts]
-    return '\n'.join(parts)
 
 
 def make_tag_from_row(name, row):

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -49,6 +49,8 @@ PACKAGE_TEMPLATE = """\
 
 
 ##############################################################################
+# MAIN LOGIC
+##############################################################################
 def handle_manifest(package_path, version, dryrun=True):
     """Convert the package.xml to a catkinized manifest.xml file.
 
@@ -117,7 +119,6 @@ def create_package_xml_str(fields):
         fields["architecture_independent"],
         fields["metapackage"]
     )
-
     return PACKAGE_TEMPLATE % subs
 
 
@@ -143,6 +144,8 @@ def get_fields_from_manifest(manifest_xml_path):
     return fields
 
 
+##############################################################################
+# Get fields from manifest.xml
 ##############################################################################
 def get_exports(manifest):
     export_tags = xml_lib.xml_find(manifest, 'export').getchildren()
@@ -181,6 +184,7 @@ def get_authors_field(manifest):
     """Extract author names and email addresses from free-form text in the
     <author> tag of manifest.xml.
 
+    TODO fix unittests
     #>>> get_authors_field('Alice/alice@somewhere.bar, Bob')
     #[('Alice', {'email': 'alice@somewhere.bar'}), 'Bob']
     #>>> get_authors_field(None)
@@ -201,6 +205,9 @@ def get_authors_field(manifest):
     return authors
 
 
+##############################################################################
+# XML formating
+# TODO why don't we use the xml package to create the xml files?
 ##############################################################################
 def make_section(tag_name, rows):
     """Make a string in XML format for a section with a given tag name."""
@@ -249,7 +256,7 @@ def indent(strg, amount=1):
 
 
 ##############################################################################
-# Utility functions
+# PATH and FILE related functions
 ##############################################################################
 def get_package_name(package_path):
     """Return the package name for the given package_path.

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -12,6 +12,8 @@ from catkinize import xml_lib
 
 
 ##############################################################################
+SPACE_COMMA_RE = re.compile(r',\s*')
+
 # The final package is going to look like the PACKAGE_TEMPLATE
 PACKAGE_TEMPLATE = """\
 <package>
@@ -19,13 +21,11 @@ PACKAGE_TEMPLATE = """\
   <version>%(version)s</version>
   <description>%(description)s</description>
 %(maintainers_part)s
-
+%(authors_part)s
 %(licenses_part)s
-
   <url type="website">%(website_url)s</url>
 %(bugtracker_part)s
 
-%(authors_part)s
 
   <!-- Dependencies which this package needs to build itself. -->
   <buildtool_depend>catkin</buildtool_depend>
@@ -56,7 +56,7 @@ def handle_manifest(package_path, version, dryrun=True):
     TODO: arguments
     """
     package_name = get_package_name(package_path)
-    manifest_xml_path = get_manifest_path(package_path)
+    manifest_xml_path = get_packg_xml_path(package_path)
     package_xml_path = get_package_xml_path(package_path)
 
     # GUARDS
@@ -69,15 +69,16 @@ def handle_manifest(package_path, version, dryrun=True):
         return False
 
     # get all fields
-    with open(manifest_xml_path) as f:
-        fields = get_fields_from_manifest(f)
+    fields = get_fields_from_manifest(manifest_xml_path)
     fields["package_name"] = package_name
     fields["version"] = version
+    for k in fields:
+        print("%s --> %s" % (k, fields[k]))
+    return False
 
     # create manifest_xml_str
     print("package.xml:")
     manifest_xml_str = create_package_xml_str(fields)
-    print(manifest_xml_str)
 
     # writing package.xml
     print("writing package.xml...")
@@ -90,9 +91,93 @@ def handle_manifest(package_path, version, dryrun=True):
 
 
 ##############################################################################
-def get_manifest_path(package_path):
-    pass
+def get_fields_from_manifest(manifest_xml_path):
+
+    with open(manifest_xml_path) as f:
+        manifest_str = f.read()
+    manifest = ET.XML(manifest_str)
+
+    # collect all fields
+    fields = {}
+
+    fields["description"] = xml_lib.xml_find(manifest, 'description').text.strip()
+
+    authors_str = xml_lib.xml_find(manifest, 'author').text
+    fields["authors"] = get_authors_field(authors_str)
+
+    licenses_str = xml_lib.xml_find(manifest, 'license').text
+    fields["licenses"] = SPACE_COMMA_RE.split(licenses_str)
+
+    fields["website_url"] = xml_lib.xml_find(manifest, 'url').text
+
+    fields["maintainers"] = [
+        (author, {'email': ''})
+        if isinstance(author, basestring)
+        else author for author in fields["authors"]]
+
+    depend_tags = manifest.findall('depend')
+    fields["depends"] = [d.attrib['package'] for d in depend_tags]
+
+    export_tags = xml_lib.xml_find(manifest, 'export').getchildren()
+    fields["exports"] = [(e.tag, e.attrib) for e in export_tags]
+
+    return fields
+
+
+def get_authors_field(authors_str):
+    """Extract author names and email addresses from free-form text in the
+    <author> tag of manifest.xml.
+
+    >>> get_authors_field('Alice/alice@somewhere.bar, Bob')
+    [('Alice', {'email': 'alice@somewhere.bar'}), 'Bob']
+    >>> get_authors_field(None)
+    []
+    """
+    if authors_str is None:
+        return []
+
+    authors = []
+    for s in SPACE_COMMA_RE.split(authors_str):
+        parts = s.split('/')
+        if len(parts) == 1:
+            authors.append(parts[0])
+        elif len(parts) == 2:
+            pair = (parts[0], dict(email=parts[1]))
+            authors.append(pair)
+    return authors
+
+
+##############################################################################
+# Utility functions
+##############################################################################
+def get_package_name(package_path):
+    """Return the package name for the given package_path.
+
+    >>> get_package_name("some/path/to/a/package/XYZ_package")
+    'XYZ_package'
+    >>> get_package_name("XYZ_package")
+    'XYZ_package'
+    """
+    return os.path.basename(os.path.abspath(package_path))
+
+
+def get_packg_xml_path(package_path):
+    """Return the path to the manifest.xml file for the given package_path.
+
+    >>> get_packg_xml_path("some/path/to/a/package/XYZ_package")
+    'some/path/to/a/package/XYZ_package/manifest.xml'
+    >>> get_packg_xml_path("XYZ_package")
+    'XYZ_package/manifest.xml'
+    """
+    return os.path.join(package_path, "manifest.xml")
 
 
 def get_package_xml_path(package_path):
-    pass
+    """Return the path to the package.xml file for the given package_path.
+
+    >>> get_package_xml_path("some/path/to/a/package/XYZ_package")
+    'some/path/to/a/package/XYZ_package/package.xml'
+    >>> get_package_xml_path("XYZ_package")
+    'XYZ_package/package.xml'
+    """
+    return os.path.join(package_path, "package.xml")

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -11,6 +11,7 @@ import re
 import xml.etree.ElementTree as ET
 
 from catkinize import xml_lib
+import utils
 
 
 ##############################################################################
@@ -60,9 +61,9 @@ def handle_manifest(package_path, version, dryrun=True):
 
     TODO: arguments
     """
-    package_name = get_package_name(package_path)
-    manifest_xml_path = get_packg_xml_path(package_path)
-    package_xml_path = get_package_xml_path(package_path)
+    package_name = utils.get_package_name(package_path)
+    manifest_xml_path = utils.get_package_path(package_path)
+    package_xml_path = utils.get_package_xml_path(package_path)
 
     # GUARDS
     if not os.path.exists(manifest_xml_path):
@@ -297,39 +298,3 @@ def space_join(words):
 
 def indent(strg, amount=1):
     return (amount * '  ') + strg
-
-
-##############################################################################
-# PATH and FILE related functions
-##############################################################################
-def get_package_name(package_path):
-    """Return the package name for the given package_path.
-
-    >>> get_package_name("some/path/to/a/package/XYZ_package")
-    'XYZ_package'
-    >>> get_package_name("XYZ_package")
-    'XYZ_package'
-    """
-    return os.path.basename(os.path.abspath(package_path))
-
-
-def get_packg_xml_path(package_path):
-    """Return the path to the manifest.xml file for the given package_path.
-
-    >>> get_packg_xml_path("some/path/to/a/package/XYZ_package")
-    'some/path/to/a/package/XYZ_package/manifest.xml'
-    >>> get_packg_xml_path("XYZ_package")
-    'XYZ_package/manifest.xml'
-    """
-    return os.path.join(package_path, "manifest.xml")
-
-
-def get_package_xml_path(package_path):
-    """Return the path to the package.xml file for the given package_path.
-
-    >>> get_package_xml_path("some/path/to/a/package/XYZ_package")
-    'some/path/to/a/package/XYZ_package/package.xml'
-    >>> get_package_xml_path("XYZ_package")
-    'XYZ_package/package.xml'
-    """
-    return os.path.join(package_path, "package.xml")

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -93,7 +93,9 @@ def handle_manifest(package_path, version, dryrun=True):
 
 def create_package_xml_str(fields):
     subs = {}
+
     subs['maintainers_part'] = make_section('maintainer', fields["maintainers"])
+
     subs['licenses_part'] = '\n'.join(
         indent('<license>%s</license>' % l)
         for l in fields["licenses"])
@@ -116,8 +118,8 @@ def create_package_xml_str(fields):
     subs['website_url'] = fields["website_url"]
     subs['exports_part'] = make_exports_section(
         fields["exports"],
-        fields["architecture_independent"],
-        fields["metapackage"]
+        False,  # TODO "architecture_independent
+        False,  # TODO "metapackage"
     )
     return PACKAGE_TEMPLATE % subs
 

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -64,6 +64,8 @@ def handle_manifest(package_path, version, dryrun=True):
     # get all fields
     with open(manifest_xml_path) as f:
         fields = get_fields_from_manifest(f)
+    fields["package_name"] = package_name
+    fields["version"] = version
 
     # create manifest_xml_str
     print("package.xml:")

--- a/catkinize/handle_manifest.py
+++ b/catkinize/handle_manifest.py
@@ -141,7 +141,8 @@ def get_fields_from_manifest(manifest_xml_path):
         "website_url": get_website_url(manifest),
         "maintainers": get_maintainers(manifest),
         "depends": get_depend(manifest),
-        "exports": get_exports(manifest)
+        "exports": get_exports(manifest),
+        "bugtracker_url": "",
     }
     return fields
 

--- a/catkinize/utils.py
+++ b/catkinize/utils.py
@@ -1,9 +1,70 @@
+import os
 import re
+import sys
 
 
+##############################################################################
 def is_valid_version(version):
     """Check if `version` is a valid version according to
     http://ros.org/reps/rep-0127.html#version
     """
     match = re.match(r'^\d+\.\d+\.\d+$', version)
     return match is not None
+
+
+def confirm(msg, confirm_key):
+    def _get_input(prompt):
+        """Helper function to provide python2 + python3 compatible get_input"""
+        if sys.hexversion > 0x03000000:
+            return input(prompt)
+        else:
+            return raw_input(prompt)
+
+    return _get_input(msg) == confirm_key
+
+
+##############################################################################
+# PATH and FILE related functions
+##############################################################################
+def get_package_name(package_path):
+    """Return the package name for the given package_path.
+
+    >>> get_package_name("some/path/to/a/package/XYZ_package")
+    'XYZ_package'
+    >>> get_package_name("XYZ_package")
+    'XYZ_package'
+    """
+    return os.path.basename(os.path.abspath(package_path))
+
+
+def get_makefile_path(package_path):
+    """Return the path of the Makefile for the given package_path.
+
+    >>> get_makefile_path("some/path/to/a/package/XYZ_package")
+    'some/path/to/a/package/XYZ_package/Makefile'
+    >>> get_makefile_path("XYZ_package")
+    'XYZ_package/Makefile'
+    """
+    return os.path.join(package_path, "Makefile")
+
+
+def get_package_path(package_path):
+    """Return the path to the manifest.xml file for the given package_path.
+
+    >>> get_package_path("some/path/to/a/package/XYZ_package")
+    'some/path/to/a/package/XYZ_package/manifest.xml'
+    >>> get_package_path("XYZ_package")
+    'XYZ_package/manifest.xml'
+    """
+    return os.path.join(package_path, "manifest.xml")
+
+
+def get_package_xml_path(package_path):
+    """Return the path to the package.xml file for the given package_path.
+
+    >>> get_package_xml_path("some/path/to/a/package/XYZ_package")
+    'some/path/to/a/package/XYZ_package/package.xml'
+    >>> get_package_xml_path("XYZ_package")
+    'XYZ_package/package.xml'
+    """
+    return os.path.join(package_path, "package.xml")

--- a/catkinize/utils.py
+++ b/catkinize/utils.py
@@ -48,12 +48,12 @@ def get_makefile_path(package_path):
     return os.path.join(package_path, "Makefile")
 
 
-def get_package_path(package_path):
+def get_manifest_xml_path(package_path):
     """Return the path to the manifest.xml file for the given package_path.
 
-    >>> get_package_path("some/path/to/a/package/XYZ_package")
+    >>> get_manifest_xml_path("some/path/to/a/package/XYZ_package")
     'some/path/to/a/package/XYZ_package/manifest.xml'
-    >>> get_package_path("XYZ_package")
+    >>> get_manifest_xml_path("XYZ_package")
     'XYZ_package/manifest.xml'
     """
     return os.path.join(package_path, "manifest.xml")


### PR DESCRIPTION
This was issue #27 (which I'll close). Here is the original text.

Catkinize offers this "changeset" or "interactive mode" feature in which it basically prints a big list of all changes. I like the idea but in my experience it is not really too useful. The list is normally too big (especially when you catkinize a stack) and you should verify the changes (probably with git, your favorite diff tool) anyway.

Also the changeset approach obfuscates what really happens. Depending on if file names in the changeset exist (and/or the content) you backup/delete/change files. This is really implicit and, as you know, "explicit is better than implicit" :)

Another point is, that the description of what is going to happen (prompt_changes()) and the logic is divided. The logic itself is also divided into create_changeset() and perform_changes().

So I propose a simplified method outlined below:
(I know it must change a bit for catkinize_stack.)

```
possible = handle_manifest(dryrun=True) and handle_cmake(dryrun=True) and handle_make(dryrun=True)

if possible and confirm('continue?'):
    handle_manifest(dryrun=False)
    handle_cmake(dryrun=False)
    handle_make(dryrun=False)
```

handle_X return True if it can perform all actions. In dryrun-mode, handle_X does not perform any file operations and therefore is side effect free.

Also the handle_X methods are more flexible that the current changeset-approach.

What do you think?

The pull request is a work in progress!
